### PR TITLE
avoid TS error from '1' as a string

### DIFF
--- a/src/ui/scripts/components/modals/ModalEventEdit.js
+++ b/src/ui/scripts/components/modals/ModalEventEdit.js
@@ -109,7 +109,7 @@ const ModalEventEdit = (props) => {
 					id: embedId,
 					readOnly: true,
 					rows: 3,
-					value: `ackeeTracker.action('${ props.id }', { key: 'Click', value: '1' })`,
+					value: `ackeeTracker.action('${ props.id }', { key: 'Click', value: 1 })`,
 					copyOnFocus: true
 				})
 


### PR DESCRIPTION
when used as is, the usage example throws:
Type 'string' is not assignable to type 'number | undefined'.  TS2322